### PR TITLE
Rebrand of BOTD

### DIFF
--- a/_clubs/gather-and-game-monday.md
+++ b/_clubs/gather-and-game-monday.md
@@ -1,19 +1,19 @@
 ---
-name: "The Brotherhood of the Dice (Tuesday)"
-day: "Tuesday"
+name: "Gather & Game Barnsley (Monday)"
+day: "Monday"
 secondary_days: []
 time: "Evenings"
 frequency: "Weekly"
 location:
-  name: "Spiral City"
+  name: "Heart of Handmade"
   address: "The Arcade, Barnsley"
   lat: 53.5530
   lng: -1.4794
-cost: "Free"
+cost: "£2 per session"
 age_restriction: ""
 website: ""
 facebook: "https://www.facebook.com/groups/612334002186959"
 description: >-
-  Weekly smaller session at Spiral City bar. Members also get 10% discount
+  Weekly smaller session at Heart of Handmade. Members also get 10% discount
   at Patriot Games (Sheffield) and Barnsley Models & Games.
 ---

--- a/_clubs/gather-and-game-saturday.md
+++ b/_clubs/gather-and-game-saturday.md
@@ -1,5 +1,5 @@
 ---
-name: "The Brotherhood of the Dice (Saturday)"
+name: "Gather & Game Barnsley (Saturday)"
 day: "Saturday"
 secondary_days: []
 time: "From 6:00pm"


### PR DESCRIPTION
Brotherhood of the dice has rebranded to "Gather and Game" as it's more inclusive name. Updated markdown accordingly
Name change.
Location/Price/Day of week updated for Monday session. Lat/Long not updated as new venue is next door to Spiral city.