### PR TITLE
Improve lat-long for farnborough-board-games.md

### DIFF
--- a/_clubs/farnborough-board-games.md
+++ b/_clubs/farnborough-board-games.md
@@ -6,8 +6,8 @@ frequency: "Weekly"
 location:
   name: "Monkey Puzzle (Brewer's Fayre)"
   address: "Monkey Puzzle (Brewer's Fayre), Farnborough, GU14 0LE"
-  lat: 51.2924771
-  lng: -0.7788702
+  lat: 51.288782720425026
+  lng: -0.7786554104110263
 cost: "Free"
 image: ""
 website: ""


### PR DESCRIPTION
The original lat-long is close to the actual venue. The updated lat-long puts the marker right on top of where we game.