### PR TITLE
Fix CI: drop description from clubs.json required-keys

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -55,7 +55,7 @@ jobs:
               exit 1
             end
 
-            required_keys = %w[name slug url days frequency location description]
+            required_keys = %w[name slug url days frequency location]
             errors = []
 
             clubs.each_with_index do |club, i|


### PR DESCRIPTION
## Problem

The **Jekyll build & JSON check** job has been failing on every PR (e.g. #126) with spurious `missing "description"` errors for all clubs.

## Cause

Commit `aae4f63` ("Improve site performance: shrink payloads") intentionally removed `description` from the `api/clubs.json` payload — the frontend's sidebar cards and map markers don't need it. But `.github/workflows/validate-pr.yml` still listed `description` in its `required_keys`, so the JSON check flagged every club as missing it. This was unrelated to any contributor's PR.

## Fix

Remove `description` from `required_keys` in the JSON check.

Per-club frontmatter still requires `description` — that's enforced by `scripts/validate_clubs.rb` (the "Validate club data" job), which is unaffected. We've only stopped requiring it in the slimmed-down `clubs.json` payload that no longer carries it.